### PR TITLE
StaticRock Bug with BadnikBreak Fix

### DIFF
--- a/Scripts/R5/StaticRock.txt
+++ b/Scripts/R5/StaticRock.txt
@@ -51,8 +51,6 @@ sub ObjectPlayerInteraction
 		break
 
 	endswitch
-else
-endif
 endsub
 
 


### PR DESCRIPTION
Fixed a statement without beginning in StaticRock.txt, this script was causing a bug that made all Badniks in Quartz Quadrant invincible if a new condition was added in the BadnikBreak function inside PlayerObject.txt. I don't see what statement would be needed in the script for a decorative rock that works so i just deleted the "else endif" to fix it.